### PR TITLE
Bump path-parse from 1.0.6 to 1.0.7 (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Logs
+.idea
+
 logs
 *.log
 npm-debug.log*

--- a/index.js
+++ b/index.js
@@ -1081,6 +1081,225 @@ class ArrayMoreKV extends ArrayMoreParent {
       )
     );
   }
+
+  last(emptyValue=null) {
+    return this.getByPosition(this.length - 1, emptyValue );
+  }
+
+  first(emptyValue=null) {
+    return this.getByPosition(0, emptyValue );
+  }
+
+  getByPosition(position, emptyValue=null) {
+    return ( this[position] === undefined ) ? emptyValue : this[position];
+  }
+
+  findByKey(key, emptyValue=null) {
+    return this.find(
+      (kv) => ArrayMore.equals(kv.key, key, false)
+    )
+  }
+
+  findByValue(value, emptyValue=null) {
+    return this.find(
+      (kv) => ArrayMore.equals(kv.value, value, false)
+    )
+  }
+
+  sqrt(emptyValue=[], invalidValue=NaN) {
+    return this.applyOperation( emptyValue, invalidValue,
+      (list) => list.map( x => Math.sqrt(x) )
+    )
+  }
+
+  round(precision=0, emptyValue=[], invalidValue=NaN) {
+    const factor = Math.pow(10,precision);
+    return this.applyOperation( emptyValue, invalidValue,
+      (list) => list.times(factor).map( x => Math.round(x) ).div(factor)
+    )
+  }
+
+  abs(emptyValue=[], invalidValue=NaN) {
+    return this.applyOperation( emptyValue, invalidValue,
+      (list) => list.map( x => Math.abs(x) )
+    )
+  }
+
+  map(callback, thisRef=undefined, castNoValueToNull=false, keepHoles=false) {
+    if( thisRef === undefined ) {
+      return ArrayMore.safeCast( this.parent().map( callback ), castNoValueToNull, keepHoles );
+    }
+    return ArrayMore.safeCast( this.parent().map( callback.bind(thisRef) ), castNoValueToNull, keepHoles );
+  }
+
+  reduce(callback, initialValue=null, emptyList = [], castNoValueToNull=false, keepHoles=false) {
+    let reduceResult;
+
+    if( initialValue === null) {
+      reduceResult = this.parent().reduce( callback );
+    } else {
+      reduceResult = this.parent().reduce( callback, initialValue );
+    }
+    return ArrayMore.safeCast( reduceResult, castNoValueToNull, keepHoles );
+  }
+
+  replaceNaN(invalidValue=NaN) {
+    if( Number.isNaN( invalidValue ) ) {
+      return this;
+    }
+    if( Number.isNaN( 1 * invalidValue ) ) {
+      throw new Error( "invalid value replacer must be a valid number" );
+    }
+    return this.map(
+      x => Number.isNaN( 1 * x ) ? invalidValue : x
+    );
+  }
+
+  rotate(rotation, emptyValue, operation, invalidValue=NaN) {
+    if( this.isEmpty() ) {
+      return ArrayMore.safeCast( emptyValue );
+    }
+    return this.replaceNaN( invalidValue ).map(
+      (x, key) => operation(
+        x,
+        this.castFunction( ArrayMore.jokerValue( this, rotation ).getRotate( key, emptyValue ) )
+      )
+    );
+  }
+
+  applyOperation(emptyValue, invalidValue, operation) {
+    if( this.isEmpty() ) {
+      return ArrayMore.safeCast( emptyValue );
+    }
+    return operation(
+      this.replaceNaN(
+        invalidValue
+      )
+    );
+  }
+
+  valuesPlus(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().plus( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesMore(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().more( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesLess(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().less( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesTimes(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().times( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesDiv(value=1, emptyValue=[], invalidValue) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().div( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesSquared(emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().squared( emptyValue, invalidValue )
+    );
+  }
+
+  valuesPow(value=2, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().pow( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesMod(value=2, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().mod( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesSin(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().sin( value, emptyValue, invalidValue )
+    );
+  }
+
+  valuesCos(value=1, emptyValue=[], invalidValue=NaN) {
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      this.getValues().cos( value, emptyValue, invalidValue )
+    );
+  }
+
+  derivate() {
+    const lastK = this.length - 1;
+    var newValues = new ArrayMore();
+    for( var i = 0; i < this.length; i++ ) {
+      if( i == 0 ) {
+        newValues.push( this[ i ].value );
+        continue;
+      }
+      const previousValues   = newValues.sum();
+      const currentDiffValue = this[ i ].value - previousValues;
+      const previousKeyValue = this[ i - 1 ].key;
+      const currentDiffKey   = this[ i ].key - previousKeyValue;
+      newValues.push( currentDiffValue / currentDiffKey );
+    }
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      newValues,
+    );
+  }
+
+  integrate(c = 0) {
+    const lastK = this.length - 1;
+    var newValues = new ArrayMore();
+    for( var i = 0; i < this.length; i++ ) {
+      const isFirst = ( i === 0 );
+      if ( isFirst ) {
+        newValues.push( this[ 0 ].value + c );
+        continue;
+      }
+      const deltaKey = this[ i ].key - this[ i - 1 ].key;
+      newValues.push(
+        newValues[ i - 1 ] +
+        ( this[ i ].value * deltaKey )
+      );
+    }
+    return ArrayMoreKV.asKV(
+      this,
+      this.getKeys(),
+      newValues,
+    );
+  }
 }
 
 module.exports = ArrayMore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arraymore.js",
-  "version": "4.0.5",
+  "version": "4.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arraymore.js",
-      "version": "4.0.5",
+      "version": "4.0.4",
       "license": "ISC",
       "devDependencies": {
         "jest": "^26.6.3"
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6400,9 +6400,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arraymore.js",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arraymore.js",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "ISC",
       "devDependencies": {
         "jest": "^26.6.3"
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6400,9 +6400,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arraymore.js",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arraymore.js",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "ISC",
       "devDependencies": {
         "jest": "^26.6.3"
@@ -2126,7 +2126,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3754,9 +3754,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4152,9 +4152,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -4218,7 +4218,7 @@
       "dev": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^4.0.0",
         "react-is": "^17.0.1"
       },
@@ -4370,7 +4370,7 @@
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7323,7 +7323,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -8570,9 +8570,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -8878,9 +8878,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "picomatch": {
@@ -8926,7 +8926,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^4.0.0",
         "react-is": "^17.0.1"
       }
@@ -9047,7 +9047,7 @@
       "dev": true,
       "requires": {
         "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       }
     },
     "resolve-cwd": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arraymore.js",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A simple combination of some map reduce functions and key value operations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arraymore.js",
-  "version": "4.0.6",
+  "version": "4.1.1",
   "description": "A simple combination of some map reduce functions and key value operations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Bump path-parse from 1.0.6 to 1.0.7

Bumps [path-parse](https://github.com/jbgutierrez/path-parse) from 1.0.6 to 1.0.7.
- [Release notes](https://github.com/jbgutierrez/path-parse/releases)
- [Commits](https://github.com/jbgutierrez/path-parse/commits/v1.0.7)

---
updated-dependencies:
- dependency-name: path-parse dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

* bump version

* Bump path-parse from 1.0.6 to 1.0.7

Bumps [path-parse](https://github.com/jbgutierrez/path-parse) from 1.0.6 to 1.0.7.
- [Release notes](https://github.com/jbgutierrez/path-parse/releases)
- [Commits](https://github.com/jbgutierrez/path-parse/commits/v1.0.7)

---
updated-dependencies:
- dependency-name: path-parse dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Thiago Mata <thiago.henrique.mata@gmail.com>